### PR TITLE
Upgraded to Akka 2.1.0-RC1 and Scala 2.10.0-RC1.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,12 @@ object Settings {
   import Resolvers._
 
   val defaultSettings = buildSettings ++ Seq(
-    resolvers ++= Seq(typesafeRepo, journalioRepo),
+    resolvers ++= Seq(
+      typesafeRepo, 
+      journalioRepo, 
+      "Akka Repo" at "http://akka.io/repository", 
+      "Sonatype Releases" at "http://oss.sonatype.org/content/repositories/releases",
+      "Sonatype Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots"),
     scalacOptions ++= Seq("-unchecked"),
     parallelExecution in Test := false
   )
@@ -32,8 +37,8 @@ object Dependencies {
 }
 
 object Version {
-  val Scala = "2.9.2"
-  val Akka  = "2.0.3"
+  val Scala = "2.10.0-RC1"
+  val Akka  = "2.1.0-RC1"
 }
 
 object Dependency {
@@ -43,18 +48,18 @@ object Dependency {
   //  Compile
   // -----------------------------------------------
 
-  val akkaActor   = "com.typesafe.akka"         %  "akka-actor"    % Akka      % "compile"
-  val akkaRemote  = "com.typesafe.akka"         %  "akka-remote"   % Akka      % "compile"
+  val akkaActor   = "com.typesafe.akka"         %  "akka-actor_2.10.0-RC1"    % Akka      % "compile"
+  val akkaRemote  = "com.typesafe.akka"         %  "akka-remote_2.10.0-RC1"   % Akka      % "compile"
   val commonsIo   = "commons-io"                %  "commons-io"    % "2.3"     % "compile"
   val journalIo   = "journalio"                 %  "journalio"     % "1.2"     % "compile"
   val levelDbJni  = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.2"     % "compile"
-  val scalaStm    = "org.scala-tools"           %% "scala-stm"     % "0.5"     % "compile"
+  val scalaStm    = "org.scala-tools"           % "scala-stm_2.10.0-RC1"     % "0.6"     % "compile"
 
   // -----------------------------------------------
   //  Test
   // -----------------------------------------------
 
-  val scalaTest = "org.scalatest" %% "scalatest" % "1.8" % "test"
+  val scalaTest = "org.scalatest" % "scalatest_2.10.0-RC1" % "1.8" % "test"
 }
 
 object EventsourcedBuild extends Build {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/src/main/scala/org/eligosource/eventsourced/core/Behavior.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Behavior.scala
@@ -30,7 +30,7 @@ import scala.collection.immutable.Stack
 trait Behavior extends Actor {
   private var behaviorStack = Stack.empty[Receive].push(super.receive)
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case msg => invoke(msg)
   }
 
@@ -39,17 +39,17 @@ trait Behavior extends Actor {
     if (head.isDefinedAt(msg)) head.apply(msg) else unhandled(msg)
   }
 
-  private [akka] override def pushBehavior(behavior: Receive) {
+  private [akka] /*override*/ def pushBehavior(behavior: Receive) {
     behaviorStack = behaviorStack.push(behavior)
   }
 
-  private [akka] override def popBehavior() {
+  private [akka] /*override*/ def popBehavior() {
     val original = behaviorStack
     val popped = original.pop
     behaviorStack = if (popped.isEmpty) original else popped
   }
 
-  private [akka] override def clearBehaviorStack() {
+  private [akka] /*override*/ def clearBehaviorStack() {
     behaviorStack = Stack.empty[Receive].push(behaviorStack.last)
   }
 }

--- a/src/main/scala/org/eligosource/eventsourced/core/Confirm.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Confirm.scala
@@ -30,7 +30,7 @@ import akka.actor._
  *   val myActor = system.actorOf(Props(new MyActor with Confirm))
  *
  *   class MyActor extends Actor {
- *     def receive = {
+ *     def receive: Receive = {
  *       case msg: Message => // ...
  *     }
  *   }
@@ -45,14 +45,14 @@ import akka.actor._
  *   val myActor = system.actorOf(Props(new MyActor with Receiver with Confirm with Eventsourced { val id = ... } ))
  *
  *   class MyActor extends Actor {
- *     def receive = {
+ *     def receive: Receive = {
  *       case event => // ...
  *     }
  *   }
  * }}}
  */
 trait Confirm extends Actor {
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case msg: Message => {
       try {
         super.receive(msg)

--- a/src/main/scala/org/eligosource/eventsourced/core/Emitter.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Emitter.scala
@@ -29,7 +29,7 @@ import akka.actor._
  *   myEmitter ! Message("foo event")
  *
  *   class MyEmitter extends Actor { this: Emitter =>
- *     def receive = {
+ *     def receive: Receive = {
  *       case "foo event" => {
  *         // emit event messages to named channels (where emitted
  *         // event messages are derived from the current message)
@@ -57,7 +57,7 @@ import akka.actor._
  *   val myEmitter = system.actorOf(Props(new MyEmitter with Emitter with Confirm with Eventsourced { val id = ... } ))
  *
  *   class MyEmitter extends Actor { this: Emitter =>
- *     def receive = {
+ *     def receive: Receive = {
  *       // ...
  *     }
  *   }
@@ -112,7 +112,7 @@ trait Emitter extends Receiver {
     new MessageEmitter(namedChannels.getOrElse(channelName, context.system.deadLetters), message)
   }
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case msg => {
       super.receive(msg)
     }

--- a/src/main/scala/org/eligosource/eventsourced/core/Eventsourced.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Eventsourced.scala
@@ -28,7 +28,7 @@ import akka.actor._
  *  val extension = EventsourcingExtension(system, journal)
  *
  *  class MyActor extends Actor {
- *    def receive = {
+ *    def receive: Receive = {
  *      case msg: Message => // journaled event message
  *      case msg          => // non-journaled message
  *    }
@@ -69,7 +69,7 @@ trait Eventsourced extends Behavior {
    */
   def id: Int
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case GetId => {
       sender ! id
     }

--- a/src/main/scala/org/eligosource/eventsourced/core/EventsourcingExtension.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/EventsourcingExtension.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 
 import akka.actor._
-import akka.util.Duration
+import concurrent.duration.{FiniteDuration, Duration}
 
 /**
  * Event-sourcing extension for Akka. Used by applications to create and register
@@ -135,9 +135,9 @@ class EventsourcingExtension(system: ActorSystem) extends Extension {
    * @return a processor ref.
    */
   def processorOf(props: Props)(implicit actorRefFactory: ActorRefFactory): ActorRef = {
-    import akka.dispatch.Await
+    import concurrent.Await
     import akka.pattern.ask
-    import akka.util.duration._
+    import concurrent.duration._
     import akka.util.Timeout
 
     implicit val duration = 5 seconds
@@ -348,13 +348,13 @@ case class ReliableChannelProps(
   /**
    * Returns a new `ReliableChannelProps` with the specified recovery delay.
    */
-  def withRecoveryDelay(recoveryDelay: Duration) =
+  def withRecoveryDelay(recoveryDelay: FiniteDuration) =
     copy(policy = policy.copy(recoveryDelay = recoveryDelay))
 
   /**
    * Returns a new `ReliableChannelProps` with the specified retry delay.
    */
-  def withRetryDelay(retryDelay: Duration) =
+  def withRetryDelay(retryDelay: FiniteDuration) =
     copy(policy = policy.copy(retryDelay = retryDelay))
 
   /**

--- a/src/main/scala/org/eligosource/eventsourced/core/Idempotent.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Idempotent.scala
@@ -26,7 +26,7 @@ import akka.actor.Actor
 trait Idempotent extends Actor {
   var lastSequenceNr = 0L
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case msg: Message => if (msg.sequenceNr > lastSequenceNr) {
       lastSequenceNr = msg.sequenceNr; super.receive(msg)
     }

--- a/src/main/scala/org/eligosource/eventsourced/core/Multicast.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Multicast.scala
@@ -17,7 +17,7 @@ package org.eligosource.eventsourced.core
 
 import akka.actor._
 import akka.pattern.ask
-import akka.util.duration._
+import concurrent.duration._
 
 /**
  * An [[org.eligosource.eventsourced.core.Eventsourced]] processor that forwards
@@ -35,7 +35,7 @@ import akka.util.duration._
  *        to `targets`.
  */
 class Multicast(targets: Seq[ActorRef], transformer: Message => Any) extends Actor { this: Eventsourced =>
-  def receive = {
+  def receive: Receive = {
     case msg: Message => targets.foreach(_ forward transformer(msg))
     case msg          => targets.foreach(_ forward msg)
   }

--- a/src/main/scala/org/eligosource/eventsourced/core/Receiver.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Receiver.scala
@@ -28,7 +28,7 @@ import akka.actor._
  *   myReceiver ! Message("foo event")
  *
  *   class MyReceiver extends Actor { this: Receiver =>
- *     def receive = {
+ *     def receive: Receive = {
  *       case "foo event" => {
  *         val msg = message          // current message
  *         val snr = sequenceNr       // sequence number of message
@@ -52,7 +52,7 @@ import akka.actor._
  *   val myReceiver = system.actorOf(Props(new MyReceiver with Receiver with Confirm with Eventsourced { val id = ... } ))
  *
  *   class MyReceiver extends Actor { this: Receiver =>
- *     def receive = {
+ *     def receive: Receive = {
  *       // ...
  *     }
  *   }
@@ -104,7 +104,7 @@ trait Receiver extends Behavior {
    */
   def confirm(pos: Boolean = true) = message.confirm(pos)
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case msg: Message => {
       _message = Some(msg)
       super.receive(msg.event)

--- a/src/main/scala/org/eligosource/eventsourced/core/Sequencer.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Sequencer.scala
@@ -30,7 +30,7 @@ trait Sequencer extends Actor {
   private val delayed = Map.empty[Long, Any]
   private var delivered = 0L
 
-  abstract override def receive = {
+  abstract override def receive: Receive = {
     case (seqnr: Long, msg) => {
       resequence(seqnr, msg)
     }

--- a/src/main/scala/org/eligosource/eventsourced/journal/InmemJournal.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/InmemJournal.scala
@@ -29,7 +29,7 @@ private [eventsourced] class InmemJournal extends Actor {
   var redoMap = SortedMap.empty[Key, Any]
   var counter = 0L
 
-  def receive = {
+  def receive: Receive = {
     case cmd: WriteInMsg => {
       val c = if(cmd.genSequenceNr) cmd.withSequenceNr(counter) else cmd
       storeInMsg(c)

--- a/src/main/scala/org/eligosource/eventsourced/journal/JournalioJournal.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/JournalioJournal.scala
@@ -56,7 +56,7 @@ private [eventsourced] class JournalioJournal(dir: File)(implicit system: ActorS
   var commandListener: Option[ActorRef] = None
   var counter = 0L
 
-  def receive = {
+  def receive: Receive = {
     case cmd: WriteInMsg => {
       val c = if(cmd.genSequenceNr) cmd.withSequenceNr(counter) else cmd
       val m = c.message.clearConfirmationSettings

--- a/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalPS.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalPS.scala
@@ -49,7 +49,7 @@ private [eventsourced] class LeveldbJournalPS(dir: File) extends Actor {
   var commandListener: Option[ActorRef] = None
   var counter = 0L
 
-  def receive = {
+  def receive: Receive = {
     case cmd: WriteInMsg => {
       val c = if(cmd.genSequenceNr) cmd.withSequenceNr(counter) else cmd
       storeInMsg(c)

--- a/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalSS.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalSS.scala
@@ -54,7 +54,7 @@ private [eventsourced] class LeveldbJournalSS(dir: File) extends Actor {
   var commandListener: Option[ActorRef] = None
   var counter = 0L
 
-  def receive = {
+  def receive: Receive = {
     case cmd: WriteInMsg => {
       val c = if(cmd.genSequenceNr) cmd.withSequenceNr(counter) else cmd
       val m = c.message.clearConfirmationSettings

--- a/src/test/scala/org/eligosource/eventsourced/core/BehaviorSpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/core/BehaviorSpec.scala
@@ -54,7 +54,7 @@ object BehaviorSpec {
       case "bar" => { destination ! ("bar (%d)" format sequenceNr); context.unbecome() }
     }
 
-    def receive = {
+    def receive: Receive = {
       case "foo" => { destination ! ("foo (%d)" format sequenceNr); context.become(changed) }
       case "baz" => { destination ! ("baz (%d)" format sequenceNr) }
     }
@@ -66,7 +66,7 @@ object BehaviorSpec {
   }
 
   class Destination(queue: java.util.Queue[Any]) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg  => queue.add(msg)
     }
   }

--- a/src/test/scala/org/eligosource/eventsourced/core/DefaultChannelSpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/core/DefaultChannelSpec.scala
@@ -100,7 +100,7 @@ class DefaultChannelSpec extends EventsourcingSpec[Fixture] {
       import fixture._
 
       val c = channel(successDestination)
-      val respondTo = ask(c) _
+      val respondTo = ask0(c) _
 
       c ! Deliver
 
@@ -126,7 +126,7 @@ object DefaultChannelSpec {
   }
 
   class Destination(queue: Queue[Message], failAtEvent: Any) extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case event => if (event == failAtEvent) {
         confirm(false)
       } else {
@@ -138,7 +138,7 @@ object DefaultChannelSpec {
   }
 
   class WriteAckListener(queue: java.util.Queue[WriteAck]) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case cmd: WriteAck => queue.add(cmd)
     }
   }

--- a/src/test/scala/org/eligosource/eventsourced/core/EventsourcingSpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/core/EventsourcingSpec.scala
@@ -18,10 +18,11 @@ package org.eligosource.eventsourced.core
 import java.io.File
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
 
+import concurrent.Await
+import concurrent.duration._
+
 import akka.actor._
-import akka.dispatch.Await
-import akka.pattern.ask
-import akka.util.duration._
+import akka.pattern._
 import akka.util.Timeout
 
 import org.apache.commons.io.FileUtils
@@ -50,6 +51,7 @@ abstract class EventsourcingSpec[T <: EventsourcingFixture[_] : ClassManifest] e
 trait EventsourcingFixture[A] {
   implicit val system = ActorSystem("test")
   implicit val timeout = Timeout(5 seconds)
+  implicit val executionContext = concurrent.ExecutionContext.global
 
   val journalDir = new File("target/journal")
   val journal = LeveldbJournal(journalDir)
@@ -69,7 +71,7 @@ trait EventsourcingFixture[A] {
     p(dequeue())
   }
 
-  def ask(actor: ActorRef)(r: Any): Any = {
+  def ask0(actor: ActorRef)(r: Any): Any = {
     Await.result(actor.ask(r), timeout.duration)
   }
 

--- a/src/test/scala/org/eligosource/eventsourced/core/GraphRecoverySpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/core/GraphRecoverySpec.scala
@@ -189,7 +189,7 @@ object GraphRecoverySpec {
     var numProcessed = 0
     var lastSenderMessageId = 0L
 
-    def receive = {
+    def receive: Receive = {
       case InputCreated(s)  => {
         emitter("processor2") sendEvent InputModified("%s-%d" format (s, numProcessed))
         numProcessed = numProcessed + 1
@@ -210,7 +210,7 @@ object GraphRecoverySpec {
   class Processor2 extends Actor { this: Emitter =>
     var numProcessed = 0
 
-    def receive = {
+    def receive: Receive = {
       case InputModified(s) => {
         val evt = InputModified("%s-%d" format (s, numProcessed))
         val sid = Some(sequenceNr.toString) // for detecting duplicates
@@ -222,13 +222,13 @@ object GraphRecoverySpec {
   }
 
   class Echo(target: ActorRef) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg: Message => target ! msg
     }
   }
 
   class Destination(queue: java.util.Queue[Message]) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg: Message => queue.add(msg)
     }
   }

--- a/src/test/scala/org/eligosource/eventsourced/core/MulticastSpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/core/MulticastSpec.scala
@@ -54,8 +54,8 @@ class MulticastSpec extends EventsourcingSpec[Fixture] {
       import fixture._
 
       val d = decorator()
-      ask(d)(Message("test")) must be("re: test")
-      ask(d)("blah")          must be("re: blah")
+      ask0(d)(Message("test")) must be("re: test")
+      ask0(d)("blah")          must be("re: blah")
     }
   }
 }
@@ -80,14 +80,14 @@ object MulticastSpec {
   }
 
   class Target(channel: ActorRef) extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case "blah" => channel forward Message("blah", ack = false)
       case event  => channel forward message
     }
   }
 
   class Destination(queue: java.util.Queue[Any]) extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case event  => {
         queue.add(event)
         sender ! ("re: %s" format event)

--- a/src/test/scala/org/eligosource/eventsourced/example/AggregatorExample.scala
+++ b/src/test/scala/org/eligosource/eventsourced/example/AggregatorExample.scala
@@ -16,8 +16,8 @@
 package org.eligosource.eventsourced.example
 
 import akka.actor._
-import akka.pattern.ask
-import akka.dispatch._
+import akka.pattern._
+import concurrent._
 
 import org.eligosource.eventsourced.core._
 
@@ -92,7 +92,7 @@ object AggregatorExample {
     var inputAggregatedCounter = 0
     var inputs = Map.empty[String, List[String]] // category -> inputs
 
-    def receive = {
+    def receive: Receive = {
       case InputAggregated(category, inputs) => {
         // count number of InputAggregated receivced
         inputAggregatedCounter = inputAggregatedCounter + 1
@@ -114,7 +114,7 @@ object AggregatorExample {
   }
 
   class Destination(queue: java.util.Queue[Message]) extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case event => queue.add(message)
     }
   }

--- a/src/test/scala/org/eligosource/eventsourced/example/BasicExample.scala
+++ b/src/test/scala/org/eligosource/eventsourced/example/BasicExample.scala
@@ -18,8 +18,8 @@ package org.eligosource.eventsourced.example
 import java.io.File
 
 import akka.actor._
-import akka.pattern.ask
-import akka.util.duration._
+import akka.pattern._
+import concurrent.duration._
 import akka.util.Timeout
 
 import org.eligosource.eventsourced.core._
@@ -28,6 +28,7 @@ import org.eligosource.eventsourced.journal.LeveldbJournal
 object BasicExample extends App {
   implicit val system = ActorSystem("example")
   implicit val timeout = Timeout(5 seconds)
+  implicit val executionContext = concurrent.ExecutionContext.global
 
   // Event sourcing extension
   val extension = EventsourcingExtension(system, LeveldbJournal(new File("target/example-2")))
@@ -65,7 +66,7 @@ object BasicExample extends App {
   // -----------------------------------------------------------
 
   class ProcessorA extends Actor {
-    def receive = {
+    def receive: Receive = {
       case event => {
         // do something with event
         println("received event = %s" format event)
@@ -74,7 +75,7 @@ object BasicExample extends App {
   }
 
   class ProcessorB extends Actor { this: Emitter with Eventsourced =>
-    def receive = {
+    def receive: Receive = {
       case "blah" => {
         println("received non-journaled message")
       }
@@ -103,7 +104,7 @@ object BasicExample extends App {
 
   // does the same as ProcessorB but doesn't use any attributes of traits Emitter and Eventsourced
   class ProcessorC(channelA: ActorRef, channelB: ActorRef) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case "blah" => {
         println("received non-journaled message")
       }
@@ -119,7 +120,7 @@ object BasicExample extends App {
   }
 
   class Destination extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case event => {
         // Receiver actors have access to:
         val msg = message          // current message

--- a/src/test/scala/org/eligosource/eventsourced/example/FsmExample.scala
+++ b/src/test/scala/org/eligosource/eventsourced/example/FsmExample.scala
@@ -27,7 +27,7 @@ class FsmExample extends EventsourcingSpec[Fixture] {
       import fixture._
 
       val door = configure()
-      val askDoor = ask(door) _
+      val askDoor = ask0(door) _
 
       extension.recover()
 
@@ -36,7 +36,7 @@ class FsmExample extends EventsourcingSpec[Fixture] {
       askDoor(Message("close")) must be(DoorNotMoved("cannot close door in state Closed"))
 
       val recoveredDoor = configure()
-      val askRecoveredDoor = ask(recoveredDoor) _
+      val askRecoveredDoor = ask0(recoveredDoor) _
 
       extension.recover()
 

--- a/src/test/scala/org/eligosource/eventsourced/example/StressExample.scala
+++ b/src/test/scala/org/eligosource/eventsourced/example/StressExample.scala
@@ -18,7 +18,7 @@ package org.eligosource.eventsourced.example
 import java.util.concurrent.TimeUnit
 
 import akka.actor._
-import akka.pattern.ask
+import akka.pattern._
 import akka.util.Timeout
 
 import org.eligosource.eventsourced.core._
@@ -70,6 +70,7 @@ object StressExample {
   }
 
   def stress(processor: ActorRef, throttle: Long)(implicit timeout: Timeout, system: ActorSystem) {
+    implicit val executionContext = concurrent.ExecutionContext.global
     val start = System.currentTimeMillis()
     1 to cycles foreach { i =>
       if (i % 100 == 0) Thread.sleep(throttle)
@@ -90,13 +91,13 @@ object StressExample {
   }
 
   class Processor(channel: ActorRef) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg: Message => channel forward msg
     }
   }
 
   class Destination(queue: java.util.Queue[Any]) extends Actor { this: Receiver =>
-    def receive = {
+    def receive: Receive = {
       case ctr: Int => {
         sender ! ctr
         if (ctr == cycles) queue.add(ctr)

--- a/src/test/scala/org/eligosource/eventsourced/guide/FirstSteps.scala
+++ b/src/test/scala/org/eligosource/eventsourced/guide/FirstSteps.scala
@@ -35,7 +35,7 @@ object FirstSteps extends App {
   class Processor(destination: ActorRef) extends Actor {
     var counter = 0
 
-    def receive = {
+    def receive: Receive = {
       case msg: Message => {
         // update internal state
         counter = counter + 1
@@ -49,7 +49,7 @@ object FirstSteps extends App {
 
   // channel destination
   class Destination extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg: Message => {
         // print event received from processor via channel
         println("[destination] event = '%s'" format msg.event)

--- a/src/test/scala/org/eligosource/eventsourced/guide/SenderReferences.scala
+++ b/src/test/scala/org/eligosource/eventsourced/guide/SenderReferences.scala
@@ -18,8 +18,8 @@ package org.eligosource.eventsourced.guide
 import java.io.File
 
 import akka.actor._
-import akka.pattern.ask
-import akka.util.duration._
+import akka.pattern._
+import concurrent.duration._
 import akka.util.Timeout
 
 import org.eligosource.eventsourced.core._
@@ -28,6 +28,7 @@ import org.eligosource.eventsourced.journal.LeveldbJournal
 object SenderReferences extends App {
   implicit val system = ActorSystem("guide")
   implicit val timeout = Timeout(5 seconds)
+  implicit val executionContext = concurrent.ExecutionContext.global
 
   // create a journal
   val journal: ActorRef = LeveldbJournal(new File("target/guide-3"))
@@ -39,7 +40,7 @@ object SenderReferences extends App {
   class Processor(destination: ActorRef) extends Actor {
     var counter = 0
 
-    def receive = {
+    def receive: Receive = {
       case msg: Message => {
         // update internal state
         counter = counter + 1
@@ -53,7 +54,7 @@ object SenderReferences extends App {
 
   // channel destination
   class Destination extends Actor {
-    def receive = {
+    def receive: Receive = {
       case msg: Message => {
         // print event received from processor via channel
         println("[destination] event = '%s'" format msg.event)

--- a/src/test/scala/org/eligosource/eventsourced/guide/StackableTraits.scala
+++ b/src/test/scala/org/eligosource/eventsourced/guide/StackableTraits.scala
@@ -35,7 +35,7 @@ object StackableTraits extends App {
   class Processor extends Actor { this: Emitter =>
     var counter = 0
 
-    def receive = {
+    def receive: Receive = {
       case event => {
         // update internal state
         counter = counter + 1
@@ -49,7 +49,7 @@ object StackableTraits extends App {
 
   // channel destination
   class Destination extends Actor {
-    def receive = {
+    def receive: Receive = {
       case event => {
         // print event received from processor via channel
         println("[destination] event = '%s'" format event)

--- a/src/test/scala/org/eligosource/eventsourced/journal/JournalSpec.scala
+++ b/src/test/scala/org/eligosource/eventsourced/journal/JournalSpec.scala
@@ -19,7 +19,7 @@ import java.io.File
 import java.util.concurrent._
 
 import akka.actor._
-import akka.util.duration._
+import concurrent.duration._
 import akka.util.Timeout
 
 import org.apache.commons.io.FileUtils
@@ -136,7 +136,7 @@ abstract class JournalSpec extends WordSpec with MustMatchers {
 
 object JournalSpec {
   class CommandTarget(queue: LinkedBlockingQueue[Message]) extends Actor {
-    def receive = {
+    def receive: Receive = {
       case Written(msg) => queue.put(msg)
     }
   }


### PR DESCRIPTION
- Added Receive as return type to all receive methods to avoid compilation error:
  `missing parameter type for expanded function
  The argument types of an anonymous function must be fully known. (SLS 8.5)
  Expected type was: scala.runtime.AbstractPartialFunction[Any,Unit] with Serializable
  abstract override def receive = {`
- Removed override modifier from pushBehavior, popBehavior and clearBehaviorStack since these methods do not override anything anymore (probably means that the behavior related functionality is now broken).
- Renamed ask method in DefaultChannelSpec to ask0 since it otherwise interfered with AskSupport
