### PR TITLE
Add OSGi meta-data to eventsourced

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,6 @@
 import sbt._
 import Keys._
+import com.typesafe.sbt.osgi.SbtOsgi.{ OsgiKeys, osgiSettings, defaultOsgiSettings }
 
 object Settings {
   val buildOrganization = "org.eligosource"
@@ -82,6 +83,19 @@ object EventsourcedBuild extends Build {
       mainRunNobootcpSetting,
       testRunNobootcpSetting,
       testNobootcpSetting
+    ) ++ osgiSettings ++ Seq(
+      OsgiKeys.importPackage := Seq(
+        "akka*;version=\"[2.1.0,3.0.0)\"",
+        "scala*;version=\"[2.10.0,2.11.0)\"",
+        "journal.io.api;version=\"[1.2,2.0)\";resolution:=optional",
+        "org.fusesource.leveldbjni;version=\"[1.4.1,2.0.0)\";resolution:=optional",
+        "org.iq80.leveldb;version=\"[1.4.1,2.0.0)\";resolution:=optional",
+        "*"
+      ),
+      OsgiKeys.exportPackage := Seq(
+        "org.eligosource*"
+      ),
+      OsgiKeys.privatePackage := Nil
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
 
+resolvers += Classpaths.typesafeResolver
+
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.5.0-SNAPSHOT")


### PR DESCRIPTION
Patch to build to add OSGi meta-data.

NOTE: I had to rebuild sbt-osgi [1] myself locally, and publish the 0.5.0-SNAPSHOT. It doesn't seem to resolve correctly from the typesafe repo.

[1] https://github.com/sbt/sbt-osgi
