### PR TITLE
Refactor project/Build.scala. Fix compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea*
 *.log
+*.iml
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -9,9 +9,12 @@ scalaVersion := "2.10.0"
 resolvers += "Journalio Repo" at "http://repo.eligotech.com/nexus/content/repositories/eligosource-releases"
 
 libraryDependencies ++= Seq(
-  "com.google.protobuf"       %  "protobuf-java"  % "2.4.1" % "compile",
-  "com.typesafe.akka"         %% "akka-actor"     % "2.1.0" % "compile",
-  "commons-io"                %  "commons-io"     % "2.3"   % "compile",
-  "journalio"                 %  "journalio"      % "1.2"   % "compile",
-  "org.fusesource.leveldbjni" %  "leveldbjni-all" % "1.4.1" % "compile"
+  "com.google.protobuf"       %  "protobuf-java"             % "2.4.1"  % "compile",
+  "com.typesafe.akka"         %% "akka-actor"                % "2.1.0"  % "compile",
+  "commons-io"                %  "commons-io"                % "2.3"    % "compile",
+  "journalio"                 %  "journalio"                 % "1.2"    % "compile",
+  "org.fusesource.leveldbjni" %  "leveldbjni-all"            % "1.4.1"  % "compile",
+  "com.typesafe.akka"         %% "akka-cluster-experimental" % "2.1.0"  % "test",
+  "org.scala-lang"            %  "scala-actors"              % "2.10.0" % "test",
+  "org.scalatest"             %% "scalatest"                 % "1.9.1"  % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,17 @@
+organization := "org.eligosource"
+
+name := "eventsourced"
+
+version := "0.5-SNAPSHOT"
+
+scalaVersion := "2.10.0"
+
+resolvers += "Journalio Repo" at "http://repo.eligotech.com/nexus/content/repositories/eligosource-releases"
+
+libraryDependencies ++= Seq(
+  "com.google.protobuf"       %  "protobuf-java"  % "2.4.1" % "compile",
+  "com.typesafe.akka"         %% "akka-actor"     % "2.1.0" % "compile",
+  "commons-io"                %  "commons-io"     % "2.3"   % "compile",
+  "journalio"                 %  "journalio"      % "1.2"   % "compile",
+  "org.fusesource.leveldbjni" %  "leveldbjni-all" % "1.4.1" % "compile"
+)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,62 +1,15 @@
 import sbt._
 import Keys._
+
 import com.typesafe.sbt.osgi.SbtOsgi.{ OsgiKeys, osgiSettings, defaultOsgiSettings }
 
+
 object Settings {
-  val buildOrganization = "org.eligosource"
-  val buildVersion      = "0.5-SNAPSHOT"
-  val buildScalaVersion = Version.Scala
-  val buildSettings = Defaults.defaultSettings ++ Seq(
-    organization := buildOrganization,
-    version      := buildVersion,
-    scalaVersion := buildScalaVersion
-  )
-
-  import Resolvers._
-
-  val defaultSettings = buildSettings ++ Seq(
-    resolvers ++= Seq(journalioRepo),
-    scalacOptions in Compile ++= Seq("-target:jvm-1.6", "-unchecked"),
+  val defaultSettings = Defaults.defaultSettings ++ Seq(
+    scalacOptions in Compile ++= Seq("-target:jvm-1.6", "-unchecked", "-feature", "-language:postfixOps", "-language:implicitConversions"),
     javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6"),
     parallelExecution in Test := false
   )
-}
-
-object Resolvers {
-  val journalioRepo = "Journalio Repo" at "http://repo.eligotech.com/nexus/content/repositories/eligosource-releases"
-}
-
-object Dependencies {
-  import Dependency._
-
-  val core = Seq(akkaActor, akkaCluster, commonsIo, journalIo, levelDbJni, protobuf, scalaTest, scalaActors)
-}
-
-object Version {
-  val Scala = "2.10.0"
-  val Akka  = "2.1.0"
-}
-
-object Dependency {
-  import Version._
-
-  // -----------------------------------------------
-  //  Compile
-  // -----------------------------------------------
-
-  val protobuf    = "com.google.protobuf"       %  "protobuf-java"  % "2.4.1" % "compile"
-  val akkaActor   = "com.typesafe.akka"         %% "akka-actor"     % Akka    % "compile"
-  val commonsIo   = "commons-io"                %  "commons-io"     % "2.3"   % "compile"
-  val journalIo   = "journalio"                 %  "journalio"      % "1.2"   % "compile"
-  val levelDbJni  = "org.fusesource.leveldbjni" %  "leveldbjni-all" % "1.4.1" % "compile"
-
-  // -----------------------------------------------
-  //  Test
-  // -----------------------------------------------
-
-  val akkaCluster = "com.typesafe.akka" %% "akka-cluster-experimental" % Akka    % "test"
-  val scalaActors = "org.scala-lang"    %  "scala-actors"              % Scala   % "test"
-  val scalaTest   = "org.scalatest"     %% "scalatest"                 % "1.9.1" % "test"
 }
 
 object Publish {
@@ -80,7 +33,6 @@ object EventsourcedBuild extends Build {
     id = "eventsourced",
     base = file("."),
     settings = defaultSettings ++ publishSettings ++ Seq(
-      libraryDependencies ++= Dependencies.core,
       mainRunNobootcpSetting,
       testRunNobootcpSetting,
       testNobootcpSetting

--- a/src/main/scala/org/eligosource/eventsourced/core/Channel.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Channel.scala
@@ -305,9 +305,9 @@ private [core] class ReliableChannelDeliverer(channelId: Int, channel: ActorRef,
     case Trigger => {
       sender ! FeedMe
     }
-    case q: Queue[Message] => {
+    case q: Queue[Any] => {
       buffer = Some(sender)
-      queue = q
+      queue = q.asInstanceOf[Queue[Message]]
       self ! Next(redeliveries)
     }
     case Next(r) => if (queue.size > 0) {

--- a/src/main/scala/org/eligosource/eventsourced/core/Confirm.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Confirm.scala
@@ -58,7 +58,7 @@ trait Confirm extends Actor {
         super.receive(msg)
         msg.confirm(true)
       } catch {
-        case e => { msg.confirm(false); throw e }
+        case e: Throwable => { msg.confirm(false); throw e }
       }
     }
     case msg => {

--- a/src/main/scala/org/eligosource/eventsourced/core/EventsourcingExtension.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/EventsourcingExtension.scala
@@ -16,7 +16,6 @@
 package org.eligosource.eventsourced.core
 
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 import scala.concurrent._
@@ -256,28 +255,28 @@ class EventsourcingExtension(system: ExtendedActorSystem) extends Extension {
   }
 
   @tailrec
-  private def registerChannel(channelId: Int, channelName: Option[String], channel: ActorRef): Unit = {
+  private def registerChannel(channelId: Int, channelName: Option[String], channel: ActorRef) {
     val current = channelsRef.get()
     val updated = if (channelName.isDefined) current.add(channelId, channelName.get, channel) else current.add(channelId, channel)
     if (!channelsRef.compareAndSet(current, updated)) registerChannel(channelId, channelName, channel)
   }
 
   @tailrec
-  private def registerProcessor(processorId: Int, processor: ActorRef): Unit = {
+  private def registerProcessor(processorId: Int, processor: ActorRef) {
     val current = processorsRef.get()
     val updated = current + (processorId -> processor)
     if (!processorsRef.compareAndSet(current, updated)) registerProcessor(processorId, processor)
   }
 
   @tailrec
-  private [core] final def deregisterChannel(channelId: Int): Unit = {
+  private [core] final def deregisterChannel(channelId: Int) {
     val current = channelsRef.get()
     val updated = current.remove(channelId)
     if (!channelsRef.compareAndSet(current, updated)) deregisterChannel(channelId)
   }
 
   @tailrec
-  private [core] final def deregisterProcessor(processorId: Int): Unit = {
+  private [core] final def deregisterProcessor(processorId: Int) {
     val current = processorsRef.get()
     val updated = current - processorId
     if (!processorsRef.compareAndSet(current, updated)) deregisterProcessor(processorId)

--- a/src/main/scala/org/eligosource/eventsourced/core/Serialization.scala
+++ b/src/main/scala/org/eligosource/eventsourced/core/Serialization.scala
@@ -15,6 +15,8 @@
  */
 package org.eligosource.eventsourced.core
 
+import scala.language.existentials
+
 import akka.actor._
 import akka.serialization.SerializationExtension
 

--- a/src/main/scala/org/eligosource/eventsourced/journal/InmemJournal.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/InmemJournal.scala
@@ -64,14 +64,14 @@ private [eventsourced] class InmemJournal extends Journal {
 
   def storedCounter = counter
 
-  private def replay(processorId: Int, channelId: Int, fromSequenceNr: Long, p: Message => Unit): Unit = {
+  private def replay(processorId: Int, channelId: Int, fromSequenceNr: Long, p: Message => Unit) {
     val startKey = Key(processorId, channelId, fromSequenceNr, 0)
     val iter = redoMap.from(startKey).iterator.buffered
     replay(iter, startKey, p)
   }
 
   @scala.annotation.tailrec
-  private def replay(iter: BufferedIterator[(Key, Any)], key: Key, p: Message => Unit): Unit = {
+  private def replay(iter: BufferedIterator[(Key, Any)], key: Key, p: Message => Unit) {
     if (iter.hasNext) {
       val nextEntry = iter.next()
       val nextKey   = nextEntry._1

--- a/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalSS.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/LeveldbJournalSS.scala
@@ -122,7 +122,7 @@ private [eventsourced] class LeveldbJournalSS(props: LeveldbJournalProps) extend
     leveldb.close()
   }
 
-  def replay[T](direction: Int, fromSequenceNr: Long, deserializer: Array[Byte] => T)(p: (T, List[Int]) => Unit): Unit = {
+  def replay[T](direction: Int, fromSequenceNr: Long, deserializer: Array[Byte] => T)(p: (T, List[Int]) => Unit) {
     val iter = leveldb.iterator(levelDbReadOptions.snapshot(leveldb.getSnapshot))
     try {
       val startKey = SSKey(direction, fromSequenceNr, 0)
@@ -134,7 +134,7 @@ private [eventsourced] class LeveldbJournalSS(props: LeveldbJournalProps) extend
   }
 
   @scala.annotation.tailrec
-  private def replay[T](iter: DBIterator, key: SSKey, deserializer: Array[Byte] => T)(p: (T, List[Int]) => Unit): Unit = {
+  private def replay[T](iter: DBIterator, key: SSKey, deserializer: Array[Byte] => T)(p: (T, List[Int]) => Unit) {
     if (iter.hasNext) {
       val nextEntry = iter.next()
       val nextKey = keyFromBytes(nextEntry.getKey)

--- a/src/main/scala/org/eligosource/eventsourced/journal/LeveldbReplay.scala
+++ b/src/main/scala/org/eligosource/eventsourced/journal/LeveldbReplay.scala
@@ -82,7 +82,7 @@ private [journal] class DefaultReplay(val context: LeveldbReplayContext) extends
     replay(Int.MaxValue, cmd.channelId, cmd.fromSequenceNr, p)
   }
 
-  def replay(processorId: Int, channelId: Int, fromSequenceNr: Long, p: Message => Unit): Unit = {
+  def replay(processorId: Int, channelId: Int, fromSequenceNr: Long, p: Message => Unit) {
     val iter = leveldb.iterator(levelDbReadOptions.snapshot(leveldb.getSnapshot))
     try {
       val startKey = Key(processorId, channelId, fromSequenceNr, 0)
@@ -94,7 +94,7 @@ private [journal] class DefaultReplay(val context: LeveldbReplayContext) extends
   }
 
   @scala.annotation.tailrec
-  final def replay(iter: DBIterator, key: Key, p: Message => Unit): Unit = {
+  final def replay(iter: DBIterator, key: Key, p: Message => Unit) {
     if (iter.hasNext) {
       val nextEntry = iter.next()
       val nextKey = keyFromBytes(nextEntry.getKey)


### PR DESCRIPTION
With build.sbt file this library may be simply used in multi-modules sbt project.
For example:

``` scala
 lazy val root = Project(id = "root", base = file(".")) aggregate(core, ...)

  lazy val core = Project(
    id = "core",
    base = file("core"),
    ...
  ) dependsOn(eventsourced)

  lazy val eventsourced = Project(id = "eventsourced", base = file("libs/eventsourced"))
```
