### PR TITLE
Standalone channel usage (closes #84)

### DIFF
--- a/es-core-test/src/test/scala/org/eligosource/eventsourced/core/BehaviorSpec.scala
+++ b/es-core-test/src/test/scala/org/eligosource/eventsourced/core/BehaviorSpec.scala
@@ -21,7 +21,7 @@ import BehaviorSpec._
 
 class BehaviorSpec extends EventsourcingSpec[Fixture] {
   "A eventsourced processor" must {
-    "can change behavior without loosing event-sourcing functionality" in { fixture =>
+    "be able to change behavior without loosing event-sourcing functionality" in { fixture =>
       import fixture._
 
       processor ! Message("foo")

--- a/es-core-test/src/test/scala/org/eligosource/eventsourced/core/ReliableChannelSpec.scala
+++ b/es-core-test/src/test/scala/org/eligosource/eventsourced/core/ReliableChannelSpec.scala
@@ -92,8 +92,8 @@ class ReliableChannelSpec extends EventsourcingSpec[Fixture] {
 
       c ! Deliver
 
-      respondTo(Message("a", processorId = 1, sequenceNr = 12L)) must be("re: a")
-      respondTo(Message("b", processorId = 1, sequenceNr = 13L)) must be("re: b")
+      respondTo(Message("a")) must be("re: a")
+      respondTo(Message("b")) must be("re: b")
     }
     "preserve the message sender before it is initialized" in { fixture =>
       import scala.concurrent._
@@ -121,7 +121,7 @@ class ReliableChannelSpec extends EventsourcingSpec[Fixture] {
       dq() must be (Left(Message("a", sequenceNr = 1L)))
       dq() must be (Right(Message("a", sequenceNr = 1L)))
     }
-    "preserve the message sender reaching maxRedelivery" in { fixture =>
+    "preserve the message sender after reaching maxRedelivery" in { fixture =>
       import fixture._
 
       val c = channel(failureDestination(failAtEvent = "a", enqueueFailures = true, failureCount = 4))
@@ -214,8 +214,8 @@ class ReliableChannelSpec extends EventsourcingSpec[Fixture] {
 
       c ! Deliver
 
-      respondTo(Message("a", processorId = 1, sequenceNr = 14L)) must be("a (6)")
-      respondTo(Message("b", processorId = 1, sequenceNr = 15L)) must be("b (14)")
+      respondTo(Message("a")) must be("a (6)")
+      respondTo(Message("b")) must be("b (14)")
     }
     "recover from destination failures and preserve message order" in { fixture =>
       import fixture._
@@ -224,7 +224,7 @@ class ReliableChannelSpec extends EventsourcingSpec[Fixture] {
 
       c ! Deliver
 
-      1 to 7 foreach { i => c ! Message(i, sequenceNr = i.toLong) }
+      1 to 7 foreach { i => c ! Message(i) }
 
       val expected = List(
         Right(Message(1, sequenceNr = 1L)), // success    at event 1

--- a/es-examples/src/main/scala/org/eligosource/eventsourced/example/StandaloneChannelExample.scala
+++ b/es-examples/src/main/scala/org/eligosource/eventsourced/example/StandaloneChannelExample.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2013 Eligotech BV.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eligosource.eventsourced.example
+
+import java.io.File
+
+import scala.concurrent.duration._
+import scala.util._
+
+import akka.actor._
+import akka.pattern.ask
+import akka.util._
+
+import org.eligosource.eventsourced.core._
+import org.eligosource.eventsourced.journal.journalio.JournalioJournalProps
+
+object StandaloneChannelExample extends App {
+  implicit val system = ActorSystem("example")
+  implicit val timeout = Timeout(50 seconds)
+
+  import system.dispatcher
+
+  val journal: ActorRef = Journal(JournalioJournalProps(new File("target/standalone")))
+  val extension = EventsourcingExtension(system, journal)
+
+  class Destination extends Actor { this: Receiver =>
+    var ctr = 0
+
+    def receive = {
+      case event => {
+        ctr += 1
+        println(s"event = ${event}, counter = ${ctr}")
+        if (ctr > 2) {
+          sender ! s"received ${event}"
+          confirm()
+          ctr = 0
+        }
+      }
+    }
+  }
+
+  val policy = RedeliveryPolicy().copy(confirmationTimeout = 1 second, restartDelay = 1 second, redeliveryDelay = 0 seconds)
+  val destination: ActorRef = system.actorOf(Props(new Destination with Receiver))
+  val channel1 = extension.channelOf(ReliableChannelProps(1, destination, policy))
+
+  extension.recover()
+
+  channel1 ? "a" onComplete {
+    case Success(r) => println(s"reply = ${r}")
+    case Failure(e) => println(s"error = ${e.getMessage}")
+  }
+
+  channel1 ? Message("b") onComplete {
+    case Success(r) => println(s"reply = ${r}")
+    case Failure(e) => println(s"error = ${e.getMessage}")
+  }
+
+  Thread.sleep(7000)
+  system.shutdown()
+}

--- a/es-journal/es-journal-common/src/main/scala/org/eligosource/eventsourced/journal/common/SenderPathReset.scala
+++ b/es-journal/es-journal-common/src/main/scala/org/eligosource/eventsourced/journal/common/SenderPathReset.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2013 Eligotech BV.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eligosource.eventsourced.journal.common
+
+import akka.actor._
+
+import org.eligosource.eventsourced.core.Message
+
+/**
+ * Used by journals to reset persistent sender paths on output event messages.
+ */
+trait SenderPathReset {
+  /**
+   * Returns the initial counter value after journal start.
+   */
+  def initialCounter: Long
+
+  /**
+   * Decorates `p` to reset `Message.senderPath`. The `senderPath` is reset if the event message
+   *
+   *  - has a `sequenceNr < initialCounter` and
+   *  - has a `senderPath` that refers to a temporary (short-lived) system actor (e.g. a future)
+   *
+   * Otherwise, the `senderPath` is not changed. This ensures that references to temporary system
+   * actors from previous application runs are not resolved.
+   *
+   * @param p event message handler.
+   * @return decorated event message handler.
+   */
+  def resetTempPath(p: Message => Unit): Message => Unit = msg =>
+    if (msg.senderPath == null) p(msg)
+    else if (ActorPath.fromString(msg.senderPath).elements.head == "temp" && msg.sequenceNr < initialCounter) p(msg.copy(senderPath = null))
+    else p(msg)
+}

--- a/es-journal/es-journal-common/src/test/scala/org/eligosource/eventsourced/journal/common/ReplaySpec.scala
+++ b/es-journal/es-journal-common/src/test/scala/org/eligosource/eventsourced/journal/common/ReplaySpec.scala
@@ -45,7 +45,7 @@ abstract class ReplaySpec extends WordSpec with MustMatchers {
 
     def receive = {
       case sr : SnapshotRequest => {
-        Thread.sleep(2) // ensure that snapshots have different timestamps
+        Thread.sleep(10) // ensure that snapshots have different timestamps
         sr.process(counter)
       }
       case so @ SnapshotOffer(Snapshot(_, _, _, ctr: Int)) => {

--- a/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSpec.scala
+++ b/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSpec.scala
@@ -15,11 +15,11 @@
  */
 package org.eligosource.eventsourced.journal.dynamodb
 
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
 import org.eligosource.eventsourced.core.JournalProps
 import akka.actor.ActorSystem
 
-class DynamoDBJournalSpec extends JournalSpec with DynamoDBJournalSupport {
+class DynamoDBJournalSpec extends PersistentJournalSpec with DynamoDBJournalSupport {
 
 
 }

--- a/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseJournalSpec.scala
+++ b/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseJournalSpec.scala
@@ -20,9 +20,9 @@ import org.apache.hadoop.hbase.client._
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
 
-class HBaseJournalSpec extends JournalSpec with HBaseCleanup with BeforeAndAfterEach with BeforeAndAfterAll {
+class HBaseJournalSpec extends PersistentJournalSpec with HBaseCleanup with BeforeAndAfterEach with BeforeAndAfterAll {
   var port: Int = 0
   var util: HBaseTestingUtility = _
   var admin: HBaseAdmin = _

--- a/es-journal/es-journal-journalio/src/main/scala/org/eligosource/eventsourced/journal/journalio/JournalioJournal.scala
+++ b/es-journal/es-journal-journalio/src/main/scala/org/eligosource/eventsourced/journal/journalio/JournalioJournal.scala
@@ -126,8 +126,11 @@ private [eventsourced] class JournalioJournal(props: JournalioJournalProps) exte
 
   def storedCounter: Long = {
     val cmds = journal.undo().asScala.map { location => cmdFromBytes(location.getData) }
-    val cmdo = cmds.collectFirst { case cmd: WriteInMsg => cmd }
-    cmdo.map(_.message.sequenceNr).getOrElse(0L)
+    val msgo = cmds.collectFirst {
+      case cmd: WriteInMsg  => cmd.message
+      case cmd: WriteOutMsg => cmd.message
+    }
+    msgo.map(_.sequenceNr).getOrElse(0L)
   }
 
   override def start() {

--- a/es-journal/es-journal-journalio/src/test/scala/org/eligosource/eventsourced/journal/journalio/JournalioJournalSpec.scala
+++ b/es-journal/es-journal-journalio/src/test/scala/org/eligosource/eventsourced/journal/journalio/JournalioJournalSpec.scala
@@ -17,14 +17,22 @@ package org.eligosource.eventsourced.journal.journalio
 
 import java.io.File
 
+import akka.actor.ActorSystem
+
 import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfterEach
 
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
+import akka.actor.ActorRef
+import org.eligosource.eventsourced.core.Journal.ReplayInMsgs
 
-class JournalioJournalSpec extends JournalSpec with BeforeAndAfterEach {
+class JournalioJournalSpec extends PersistentJournalSpec with BeforeAndAfterEach {
   val journalDir = new File("es-journal/es-journal-journalio/target/journal")
   def journalProps = JournalioJournalProps(journalDir)
+
+  override def prepareJournal(journal: ActorRef, system: ActorSystem) {
+    journal ! ReplayInMsgs(1, 0, system.deadLetters)
+  }
 
   override def afterEach() {
     FileUtils.deleteDirectory(journalDir)

--- a/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbJournalSpec.scala
+++ b/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbJournalSpec.scala
@@ -22,9 +22,9 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.eligosource.eventsourced.core._
 import org.eligosource.eventsourced.core.Journal._
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common._
 
-abstract class LeveldbJournalPSSpec extends JournalSpec {
+abstract class LeveldbJournalSpec extends PersistentJournalSpec {
   import JournalSpec._
 
   "persist input messages with a custom event serializer" in { fixture =>
@@ -51,22 +51,22 @@ abstract class LeveldbJournalPSSpec extends JournalSpec {
   }
 }
 
-object LeveldbJournalPSSpec {
+object LeveldbJournalSpec {
   val journalDir = new File("es-journal/es-journal-leveldb/target/journal")
 }
 
-class LeveldbJournalPSDefaultSpec extends LeveldbJournalPSSpec with BeforeAndAfterEach {
-  def journalProps = LeveldbJournalProps(LeveldbJournalPSSpec.journalDir)
+class LeveldbJournalPSSpec extends LeveldbJournalSpec with BeforeAndAfterEach {
+  def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir)
 
   override def afterEach() {
-    FileUtils.deleteDirectory(LeveldbJournalPSSpec.journalDir)
+    FileUtils.deleteDirectory(LeveldbJournalSpec.journalDir)
   }
 }
 
 class LeveldbJournalSSSpec extends JournalSpec with BeforeAndAfterEach {
-  def journalProps = LeveldbJournalProps(LeveldbJournalPSSpec.journalDir).withSequenceStructure
+  def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir).withSequenceStructure
 
   override def afterEach() {
-    FileUtils.deleteDirectory(LeveldbJournalPSSpec.journalDir)
+    FileUtils.deleteDirectory(LeveldbJournalSpec.journalDir)
   }
 }

--- a/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbReplaySpec.scala
+++ b/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbReplaySpec.scala
@@ -21,17 +21,17 @@ import org.scalatest.BeforeAndAfterEach
 import org.eligosource.eventsourced.journal.common.ReplaySpec
 
 class LeveldbReplayPSSpec extends ReplaySpec with BeforeAndAfterEach {
-  def journalProps = LeveldbJournalProps(LeveldbJournalPSSpec.journalDir)
+  def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir)
 
   override def afterEach() {
-    FileUtils.deleteDirectory(LeveldbJournalPSSpec.journalDir)
+    FileUtils.deleteDirectory(LeveldbJournalSpec.journalDir)
   }
 }
 
 class LeveldbReplaySSSpec extends ReplaySpec with BeforeAndAfterEach {
-  def journalProps = LeveldbJournalProps(LeveldbJournalPSSpec.journalDir).withSequenceStructure
+  def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir).withSequenceStructure
 
   override def afterEach() {
-    FileUtils.deleteDirectory(LeveldbJournalPSSpec.journalDir)
+    FileUtils.deleteDirectory(LeveldbJournalSpec.journalDir)
   }
 }

--- a/es-journal/es-journal-mongodb-casbah/src/test/scala/org/eligosource/eventsourced/journal/mongodb/casbah/MongodbCasbahJournalSpec.scala
+++ b/es-journal/es-journal-mongodb-casbah/src/test/scala/org/eligosource/eventsourced/journal/mongodb/casbah/MongodbCasbahJournalSpec.scala
@@ -17,9 +17,9 @@ package org.eligosource.eventsourced.journal.mongodb.casbah
 
 import org.scalatest.BeforeAndAfterEach
 import com.mongodb.casbah.Imports._
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
 
-class MongodbCasbahJournalSpec extends JournalSpec with MongodbSpecSupport with BeforeAndAfterEach {
+class MongodbCasbahJournalSpec extends PersistentJournalSpec with MongodbSpecSupport with BeforeAndAfterEach {
 
   val dbName = "es2"
   val collName = "event"

--- a/es-journal/es-journal-mongodb-reactive/src/it/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournalSpec.scala
+++ b/es-journal/es-journal-mongodb-reactive/src/it/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournalSpec.scala
@@ -21,7 +21,7 @@ import de.flapdoodle.embed.process.runtime.Network
 
 import org.eligosource.eventsourced.core._
 import org.eligosource.eventsourced.core.Journal._
-import org.eligosource.eventsourced.journal.common.JournalSpec
+import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import reactivemongo.api.{DB, MongoConnection}
@@ -32,7 +32,7 @@ import de.flapdoodle.embed.process.config.io.ProcessOutput
 import de.flapdoodle.embed.process.io.{NullProcessor, Processors}
 import de.flapdoodle.embed.mongo.config.{MongodConfig, RuntimeConfigBuilder}
 
-class MongodbReactiveJournalSpec extends JournalSpec with BeforeAndAfterEach with BeforeAndAfterAll {
+class MongodbReactiveJournalSpec extends PersistentJournalSpec with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
   implicit val duration = 10 seconds


### PR DESCRIPTION
- Channel accepts event messages with processor id 0
- Channel accepts plain events
- Standalone channel usage example
- Fix erroneous sequence number recovery with Journal.IO (closes #95)
- Reset temporary sender paths for previously persisted output messages
- Undo temporary changes in ReliableChannelSpec
- Additional tests
  - sequence number recovery
  - sender path reset
