### PR TITLE
Snapshotting for HBase journal (closes #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,14 @@ The behavior of [`Eventsourced`](http://eligosource.github.com/eventsourced/api/
 Snapshots
 ---------
 
-Snapshots represent processor state at a certain point in time and can dramatically reduce [recovery](#recovery) times. Snapshot capturing and saving is triggered by applications. Saving is done in a journal-specific way. At the moment, only the [LevelDB journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.leveldb.LeveldbJournalProps), [Journal.IO journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.journalio.JournalioJournalProps) and the [In-memory journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.inmem.InmemJournalProps) support snapshotting. The remaining [journals](#journals) will follow soon. Snapshot capturing and saving does not delete entries from the event message history unless explicitly requested by an application.
+Snapshots represent processor state at a certain point in time and can dramatically reduce [recovery](#recovery) times. Snapshot capturing and saving is triggered by applications. Saving is done in a journal-specific way. At the moment, the following journals support snapshotting:
+
+- [HBase journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.hbase.HBaseJournalProps): saves snapshots to a configurable Hadoop [`FileSystem`](http://hadoop.apache.org/docs/r1.1.2/api/org/apache/hadoop/fs/FileSystem.html). By default the local filesystem is used. Production deployments should use another filesystem (HDFS, for example).
+- [LevelDB journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.leveldb.LeveldbJournalProps): saves snapshots to the local filesystem.
+- [Journal.IO journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.journalio.JournalioJournalProps): saves snapshots to the local filesystem.
+- [In-memory journal](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.inmem.InmemJournalProps): keeps snapshots in-memory only.
+
+Snapshot capturing and saving does not delete entries from the event message history unless explicitly requested by an application.
 
 Applications can create snapshots by sending a processor the [`SnapshotRequest`](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.core.SnapshotRequest$) message.
 

--- a/es-core/src/main/scala/org/eligosource/eventsourced/core/Journal.scala
+++ b/es-core/src/main/scala/org/eligosource/eventsourced/core/Journal.scala
@@ -166,12 +166,28 @@ object Journal {
    *
    * @param channelId id of the reliable channel.
    * @param fromSequenceNr sequence number from where the replay should start.
+   * @param toSequenceNr sequence number where the replay should end (inclusive).
    * @param target receiver of the replayed messages. The journal sends the
    *        replayed messages to `target` wrapped in a
    *        [[org.eligosource.eventsourced.core.Journal.Written]] message. The
    *        sender reference is set to `system.deadLetters`.
    */
-  case class ReplayOutMsgs(channelId: Int, fromSequenceNr: Long, target: ActorRef)
+  case class ReplayOutMsgs(channelId: Int, fromSequenceNr: Long, toSequenceNr: Long, target: ActorRef)
+
+  object ReplayOutMsgs {
+    /**
+     * Creates a `ReplayOutMsgs` command with `toSequenceNr` set to `Long.MaxValue`.
+     *
+     * @param channelId id of the reliable channel.
+     * @param fromSequenceNr sequence number from where the replay should start.
+     * @param target receiver of the replayed messages. The journal sends the
+     *        replayed messages to `target` wrapped in a
+     *        [[org.eligosource.eventsourced.core.Journal.Written]] message. The
+     *        sender reference is set to `system.deadLetters`.
+     */
+    def apply(channelId: Int, fromSequenceNr: Long, target: ActorRef) =
+      new ReplayOutMsgs(channelId, fromSequenceNr, Long.MaxValue, target)
+  }
 
   /**
    * Instructs a journal to request a state snapshot from a processor identified by

--- a/es-core/src/main/scala/org/eligosource/eventsourced/core/ReplayParams.scala
+++ b/es-core/src/main/scala/org/eligosource/eventsourced/core/ReplayParams.scala
@@ -46,6 +46,11 @@ sealed trait ReplayParams {
    * number (if any) will be the replay starting point.
    */
   def snapshotFilter: SnapshotMetadata => Boolean
+
+  /**
+   * Updates `toSequenceNr` with specified value.
+   */
+  def withToSequenceNr(toSequenceNr: Long): ReplayParams
 }
 
 /**
@@ -107,6 +112,12 @@ object ReplayParams {
      * Not applicable.
      */
     def snapshotFilter = _ => false
+
+    /**
+     * Updates `toSequenceNr` with specified value.
+     */
+    def withToSequenceNr(toSequenceNr: Long) =
+      copy(toSequenceNr = toSequenceNr)
   }
 
   /**
@@ -136,5 +147,11 @@ object ReplayParams {
      */
     def snapshotFilter: SnapshotMetadata => Boolean =
       smd => snapshotBaseFilter(smd) && (smd.sequenceNr <= toSequenceNr)
+
+    /**
+     * Updates `toSequenceNr` with specified value.
+     */
+    def withToSequenceNr(toSequenceNr: Long) =
+      copy(toSequenceNr = toSequenceNr)
   }
 }

--- a/es-journal/es-journal-common/src/main/scala/org/eligosource/eventsourced/journal/common/serialization/package.scala
+++ b/es-journal/es-journal-common/src/main/scala/org/eligosource/eventsourced/journal/common/serialization/package.scala
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.eligosource.eventsourced.journal.leveldb
+package org.eligosource.eventsourced.journal.common
 
-import java.io._
+import org.eligosource.eventsourced.core.SnapshotMetadata
 
-import akka.actor.Actor
-
-import org.eligosource.eventsourced.journal.common.serialization._
-
-private [leveldb] trait LeveldbSnapshotting extends LocalFilesystemSnapshotting { this: Actor =>
-  def props: LeveldbJournalProps
-  def snapshotSerializer = props.snapshotSerializer
-  def snapshotSaveTimeout = props.snapshotSaveTimeout
-
-  val snapshotDir: File =
-    if (props.snapshotDir.isAbsolute) props.snapshotDir
-    else new File(props.dir, props.snapshotDir.getPath)
+package object serialization {
+  implicit val snapshotMetadataOrdering = new Ordering[SnapshotMetadata] {
+    def compare(x: SnapshotMetadata, y: SnapshotMetadata) =
+      if (x.processorId == y.processorId) math.signum(x.sequenceNr - y.sequenceNr).toInt
+      else x.processorId - y.processorId
+  }
 }
-

--- a/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
+++ b/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
@@ -8,7 +8,6 @@ trait DynamoDBJournalSupport {
     val secret = sys.env("AWS_SECRET_ACCESS_KEY")
     val table = sys.env("TEST_TABLE")
     val app = System.currentTimeMillis().toString
-    val concurrency = sys.env.get("CONCURRENCY").map(_.toInt).getOrElse(4)
-    DynamoDBJournalProps(table, app, key, secret, asyncWriterCount = concurrency, counterShards = 10, system = ActorSystem("dynamo-test"))
+    DynamoDBJournalProps(table, app, key, secret, counterShards = 10, system = ActorSystem("dynamo-test"))
   }
 }

--- a/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalProps.scala
+++ b/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalProps.scala
@@ -31,7 +31,7 @@ case class DynamoDBJournalProps(journalTable: String, eventSourcedApp: String,
                                 key: String, secret: String,
                                 operationTimeout: Timeout = Timeout(10 seconds),
                                 replayOperationTimeout: Timeout = Timeout(1 minute),
-                                asyncWriterCount: Int = 16, counterShards:Int=10000,
+                                counterShards:Int=10000,
                                 system: ActorSystem, factory: Option[ActorRefFactory] = None,
                                 dynamoEndpoint:String = "dynamodb.us-east-1.amazonaws.com",
                                 val name: Option[String] = None, val dispatcherName: Option[String] = None) extends JournalProps {

--- a/es-journal/es-journal-hbase/readme.md
+++ b/es-journal/es-journal-hbase/readme.md
@@ -71,3 +71,17 @@ For storing event messages to a real HBase cluster, a table must be initially cr
     }
 
 This creates an event message table with the name `event` that is pre-split into 16 regions. The journal actor will evenly distribute (partition) event messages across regions.
+
+Snapshots
+---------
+
+The HBase journal uses a Hadoop [`FileSystem`](http://hadoop.apache.org/docs/r1.1.2/api/org/apache/hadoop/fs/FileSystem.html) instance for saving snapshots. By default, snapshots are saved to the local filesystem. Applications may also provide other `FileSystem` instances (e.g. for saving snapshots to HDFS), as shown in the following example:
+
+    ...
+    import org.apache.hadoop.fs.FileSystem
+
+    ...
+    val hdfs: FileSystem = FileSystem.get(...)
+    val journal: ActorRef = Journal(HBaseJournalProps(..., snapshotFilesystem = hdfs))
+
+Find out more in the [HBaseJournalProps](http://eligosource.github.com/eventsourced/api/snapshot/#org.eligosource.eventsourced.journal.hbase.HBaseJournalProps) API docs.

--- a/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseSpec.scala
+++ b/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseSpec.scala
@@ -18,11 +18,11 @@ package org.eligosource.eventsourced.journal.hbase
 import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
 
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
-import org.eligosource.eventsourced.journal.common.PersistentJournalSpec
+import org.eligosource.eventsourced.journal.common.{PersistentReplaySpec, PersistentJournalSpec}
 
-class HBaseJournalSpec extends PersistentJournalSpec with HBaseCleanup with BeforeAndAfterEach with BeforeAndAfterAll {
+trait HBaseSpec extends HBaseCleanup with BeforeAndAfterEach with BeforeAndAfterAll { self: Suite =>
   var port: Int = 0
   var util: HBaseTestingUtility = _
   var admin: HBaseAdmin = _
@@ -31,8 +31,8 @@ class HBaseJournalSpec extends PersistentJournalSpec with HBaseCleanup with Befo
   def zookeeperQuorum = "localhost:%d" format port
   def journalProps = {
     HBaseJournalProps(zookeeperQuorum)
-      .withWriterCount(4)
       .withReplayChunkSize(8)
+      .withSnapshotFilesystem(util.getTestFileSystem)
   }
 
   override def afterEach() {
@@ -54,3 +54,6 @@ class HBaseJournalSpec extends PersistentJournalSpec with HBaseCleanup with Befo
     util.cleanupTestDir()
   } catch { case _: Throwable => /* ignore */ }
 }
+
+class HBaseJournalSpec extends PersistentJournalSpec with HBaseSpec
+class HBaseReplaySpec extends PersistentReplaySpec with HBaseSpec

--- a/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseSupport.scala
+++ b/es-journal/es-journal-hbase/src/it/scala/org/eligosource/eventsourced/journal/hbase/HBaseSupport.scala
@@ -25,7 +25,5 @@ object HBaseSupport {
 
 trait HBaseSupport extends HBaseCleanup {
   val client = HBaseSupport.client
-  val journalProps = HBaseJournalProps("localhost")
-    .withWriterCount(4)
-    .withReplayChunkSize(8)
+  val journalProps = HBaseJournalProps("localhost").withReplayChunkSize(8)
 }

--- a/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/HBaseSnapshotting.scala
+++ b/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/HBaseSnapshotting.scala
@@ -13,21 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.eligosource.eventsourced.journal.leveldb
-
-import java.io._
+package org.eligosource.eventsourced.journal.hbase
 
 import akka.actor.Actor
 
-import org.eligosource.eventsourced.journal.common.serialization._
+import org.eligosource.eventsourced.journal.hbase.serialization.HadoopFilesystemSnapshotting
 
-private [leveldb] trait LeveldbSnapshotting extends LocalFilesystemSnapshotting { this: Actor =>
-  def props: LeveldbJournalProps
+import org.apache.hadoop.fs.Path
+
+private [hbase] trait HBaseSnapshotting extends HadoopFilesystemSnapshotting { this: Actor =>
+  def props: HBaseJournalProps
+
+  def snapshotFilesystem = props.snapshotFilesystem
   def snapshotSerializer = props.snapshotSerializer
-  def snapshotSaveTimeout = props.snapshotSaveTimeout
+  def snapshotSaveTimeout = props.snapshotLoadTimeout
+  def snapshotLoadTimeout = props.snapshotSaveTimeout
 
-  val snapshotDir: File =
+  val snapshotDir =
     if (props.snapshotDir.isAbsolute) props.snapshotDir
-    else new File(props.dir, props.snapshotDir.getPath)
+    else new Path(snapshotFilesystem.getWorkingDirectory, props.snapshotDir)
 }
-

--- a/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/package.scala
+++ b/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/package.scala
@@ -76,18 +76,16 @@ package object hbase {
     def withPartition(p: Int) = copy(partition = p)
   }
 
-  private [hbase] case class CounterKey(partition: Int, writerId: Int) extends Key {
-    require(sequenceNumber == 0 || sequenceNumber == 1)
+  private [hbase] case class CounterKey(partition: Int, sequenceNumber: Long) extends Key {
     val source = 0
-    val sequenceNumber = writerId.toLong
-    def withSequenceNumber(f: (Long) => Long) = copy(writerId = f(writerId).toInt)
+    def withSequenceNumber(f: (Long) => Long) =  copy(sequenceNumber = f(sequenceNumber))
     def withPartition(p: Int) = copy(partition = p)
   }
 
   private [hbase] case class PartitionCountKey(upper: Boolean = false) extends Key {
     val partition = -1
     val source = 0
-    def sequenceNumber = if (upper) 1L else 0L
+    val sequenceNumber = if (upper) 1L else 0L
 
     def withPartition(p: Int) =
       throw new UnsupportedOperationException("withPartition on PartitionCountKey")

--- a/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/serialization/HadoopFilesystemSnapshotting.scala
+++ b/es-journal/es-journal-hbase/src/main/scala/org/eligosource/eventsourced/journal/hbase/serialization/HadoopFilesystemSnapshotting.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2012-2013 Eligotech BV.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eligosource.eventsourced.journal.hbase.serialization
+
+import java.io._
+
+import scala.annotation.tailrec
+import scala.collection.SortedSet
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util._
+
+import akka.actor._
+import akka.pattern.ask
+import akka.util.Timeout
+
+import org.apache.hadoop.fs.{Path, FileSystem}
+
+import org.eligosource.eventsourced.core._
+import org.eligosource.eventsourced.journal.common.serialization._
+
+private [journal] trait HadoopFilesystemSnapshotting { outer: Actor =>
+  private val FilenamePattern = """^snapshot-(\d+)-(\d+)-(\d+)""".r
+  private var snapshotMetadata = Map.empty[Int, SortedSet[SnapshotMetadata]]
+
+  lazy val snapshotSerialization = new SnapshotSerialization {
+    val snapshotAccess = new HadoopFilesystemSnapshotAccess(snapshotDir, snapshotFilesystem)
+    val snapshotSerializer = outer.snapshotSerializer
+  }
+
+  def snapshotDir: Path
+  def snapshotFilesystem: FileSystem
+  def snapshotSerializer: SnapshotSerializer
+
+  def snapshotSaveTimeout: FiniteDuration
+  def snapshotLoadTimeout: FiniteDuration
+
+  def createSnapshotter =
+    context.actorOf(Props(new SnapshotIO(snapshotMetadata)).withDispatcher("eventsourced.journal.snapshot-dispatcher"))
+
+  def loadSnapshot(processorId: Int, snapshotFilter: SnapshotMetadata => Boolean): Future[Option[Snapshot]] =
+    createSnapshotter.ask(SnapshotIO.LoadSnapshot(processorId, snapshotFilter))(Timeout(snapshotLoadTimeout)).mapTo[Option[Snapshot]]
+
+  def saveSnapshot(snapshot: Snapshot): Future[SnapshotSaved] =
+    createSnapshotter.ask(SnapshotIO.SaveSnapshot(snapshot))(Timeout(snapshotSaveTimeout)).mapTo[SnapshotSaved]
+
+  def snapshotSaved(metadata: SnapshotMetadata) {
+    snapshotMetadata.get(metadata.processorId) match {
+      case None      => snapshotMetadata = snapshotMetadata + (metadata.processorId -> SortedSet(metadata))
+      case Some(mds) => snapshotMetadata = snapshotMetadata + (metadata.processorId -> (mds + metadata))
+    }
+  }
+
+  def initSnapshotting() {
+    if (!snapshotFilesystem.exists(snapshotDir)) snapshotFilesystem.mkdirs(snapshotDir)
+
+    val metadata = snapshotFilesystem.listStatus(snapshotDir).map(_.getPath.getName).collect {
+      case FilenamePattern(pid, snr, tms) => SnapshotSaved(pid.toInt, snr.toLong, tms.toLong)
+    }
+
+    snapshotMetadata = SortedSet.empty[SnapshotMetadata] ++ metadata groupBy(_.processorId)
+  }
+
+  private class SnapshotIO(snapshotMetadata: Map[Int, SortedSet[SnapshotMetadata]]) extends Actor {
+    import SnapshotIO._
+
+    def receive = {
+      case SaveSnapshot(s) => {
+        Try(snapshotSerialization.serializeSnapshot(s)) match {
+          case Success(_) => sender ! SnapshotSaved(s.processorId, s.sequenceNr, s.timestamp)
+          case Failure(e) => sender ! Status.Failure(e)
+        }
+        context.stop(self)
+      }
+      case LoadSnapshot(processorId, snapshotFilter) => {
+        sender ! loadSnapshot(processorId, snapshotFilter)
+        context.stop(self)
+      }
+    }
+
+    def loadSnapshot(processorId: Int, snapshotFilter: SnapshotMetadata => Boolean): Option[Snapshot] = {
+      @tailrec
+      def go(metadata: SortedSet[SnapshotMetadata]): Option[Snapshot] = metadata.lastOption match {
+        case None     => None
+        case Some(md) => {
+          Try(snapshotSerialization.deserializeSnapshot(md)) match {
+            case Success(ss) => Some(ss)
+            case Failure(_)  => go(metadata.init) // try older snapshot
+          }
+        }
+      }
+
+      for {
+        mds <- snapshotMetadata.get(processorId)
+        md  <- go(mds.filter(snapshotFilter))
+      } yield md
+    }
+  }
+
+  private object SnapshotIO {
+    case class SaveSnapshot(s: Snapshot)
+    case class LoadSnapshot(processorId: Int, snapshotFilter: SnapshotMetadata => Boolean)
+  }
+}
+
+private [hbase] class HadoopFilesystemSnapshotAccess(snapshotDir: Path, snapshotFilesystem: FileSystem) extends SnapshotAccess {
+  def withOutputStream(metadata: SnapshotMetadata)(p: (OutputStream) => Unit) =
+    withStream(snapshotFilesystem.create(snapshotFile(metadata)), p)
+
+  def withInputStream(metadata: SnapshotMetadata)(p: (InputStream) => Any) =
+    withStream(snapshotFilesystem.open(snapshotFile(metadata)), p)
+
+  private def withStream[A <: Closeable, B](stream: A, p: A => B): B =
+    try { p(stream) } finally { stream.close() }
+
+  private def snapshotFile(metadata: SnapshotMetadata): Path =
+    new Path(snapshotDir, s"snapshot-${metadata.processorId}-${metadata.sequenceNr}-${metadata.timestamp}")
+}
+

--- a/es-journal/es-journal-journalio/src/main/scala/org/eligosource/eventsourced/journal/journalio/JournalioSnapshotting.scala
+++ b/es-journal/es-journal-journalio/src/main/scala/org/eligosource/eventsourced/journal/journalio/JournalioSnapshotting.scala
@@ -21,7 +21,7 @@ import akka.actor.Actor
 
 import org.eligosource.eventsourced.journal.common.serialization._
 
-private [journalio] trait JournalioSnapshotting extends FilesystemSnapshotting { this: Actor =>
+private [journalio] trait JournalioSnapshotting extends LocalFilesystemSnapshotting { this: Actor =>
   def props: JournalioJournalProps
   def snapshotSerializer = props.snapshotSerializer
   def snapshotSaveTimeout = props.snapshotSaveTimeout

--- a/es-journal/es-journal-journalio/src/test/scala/org/eligosource/eventsourced/journal/journalio/JournalioReplaySpec.scala
+++ b/es-journal/es-journal-journalio/src/test/scala/org/eligosource/eventsourced/journal/journalio/JournalioReplaySpec.scala
@@ -18,9 +18,9 @@ package org.eligosource.eventsourced.journal.journalio
 import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfterEach
 
-import org.eligosource.eventsourced.journal.common.ReplaySpec
+import org.eligosource.eventsourced.journal.common.PersistentReplaySpec
 
-class JournalioReplaySpec extends ReplaySpec with BeforeAndAfterEach {
+class JournalioReplaySpec extends PersistentReplaySpec with BeforeAndAfterEach {
   def journalProps = JournalioJournalProps(JournalioJournalSpec.journalDir)
 
   override def afterEach() {

--- a/es-journal/es-journal-leveldb/src/main/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbJournalProps.scala
+++ b/es-journal/es-journal-leveldb/src/main/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbJournalProps.scala
@@ -56,7 +56,7 @@ import org.eligosource.eventsourced.journal.common.serialization.SnapshotSeriali
  *        id, `false` if entries are ordered by sequence number.  Default is `true`.
  * @param snapshotDir Directory where the journal will store snapshots. A relative
  *        path is relative to `dir`.
- * @param snapshotSerializer serializer for writing and reading snapshots.
+ * @param snapshotSerializer Serializer for writing and reading snapshots.
  * @param snapshotSaveTimeout Timeout for saving a snapshot.
  */
 case class LeveldbJournalProps(

--- a/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbReplaySpec.scala
+++ b/es-journal/es-journal-leveldb/src/test/scala/org/eligosource/eventsourced/journal/leveldb/LeveldbReplaySpec.scala
@@ -18,9 +18,9 @@ package org.eligosource.eventsourced.journal.leveldb
 import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfterEach
 
-import org.eligosource.eventsourced.journal.common.ReplaySpec
+import org.eligosource.eventsourced.journal.common.PersistentReplaySpec
 
-class LeveldbReplayPSSpec extends ReplaySpec with BeforeAndAfterEach {
+class LeveldbReplayPSSpec extends PersistentReplaySpec with BeforeAndAfterEach {
   def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir)
 
   override def afterEach() {
@@ -28,7 +28,7 @@ class LeveldbReplayPSSpec extends ReplaySpec with BeforeAndAfterEach {
   }
 }
 
-class LeveldbReplaySSSpec extends ReplaySpec with BeforeAndAfterEach {
+class LeveldbReplaySSSpec extends PersistentReplaySpec with BeforeAndAfterEach {
   def journalProps = LeveldbJournalProps(LeveldbJournalSpec.journalDir).withSequenceStructure
 
   override def afterEach() {

--- a/es-journal/es-journal-mongodb-reactive/src/main/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournalProps.scala
+++ b/es-journal/es-journal-mongodb-reactive/src/main/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournalProps.scala
@@ -44,8 +44,6 @@ import reactivemongo.core.actors.Authenticate
  * @param collName Optional mongoDB collection name. Defaults to {@see DefaultCollectionName}
  * @param name Optional journal actor name.
  * @param dispatcherName Optional journal actor dispatcher name.
- * @param writerCount Number of concurrent writers.
- * @param writeTimeout Timeout for asynchronous writes.
  * @param initTimeout Timeout for journal initialization. During initialization
  *        the highest stored sequence number is loaded from the event message table.
  * @param replayChunkSize Maximum number of event messages to keep in memory during replay.
@@ -61,8 +59,6 @@ case class MongodbReactiveJournalProps(
   collName: String = DefaultCollectionName,
   name: Option[String] = None,
   dispatcherName: Option[String] = None,
-  writerCount: Int = 16,
-  writeTimeout: FiniteDuration = 10 seconds,
   initTimeout: FiniteDuration = 30 seconds,
   replayChunkSize: Int = 16 * 100) extends JournalProps {
 
@@ -87,14 +83,8 @@ case class MongodbReactiveJournalProps(
   /** Returns a new `MongodbReactiveJournalProps` with specified journal actor dispatcher name. */
   def withDispatcherName(dispatcherName: String) = copy(dispatcherName = Some(dispatcherName))
 
-  /** Returns a new `MongodbReactiveJournalProps` with specified writer count value. */
-  def withWriterCount(writerCount: Int) = copy(writerCount = writerCount)
-
-  /** Returns a new `MongodbReactiveJournalProps` with specified write timeout. */
-  def withWriteTimeout(writeTimeout: FiniteDuration) = copy(writeTimeout = writeTimeout)
-
   /** Returns a new `MongodbReactiveJournalProps` with specified init timeout. */
-  def withInitTimeout(initTimeout: FiniteDuration) = copy(writeTimeout = writeTimeout)
+  def withInitTimeout(initTimeout: FiniteDuration) = copy(initTimeout = initTimeout)
 
   /** Returns a new `MongodbReactiveJournalProps` with specified replay chunk size. */
   def withReplayChunkSize(replayChunkSize: Int) = copy(replayChunkSize = replayChunkSize)


### PR DESCRIPTION
- common snapshotting functionality in AsynchronousWriteReplaySupport
- Hadoop FileSystem based snapshot storage
- Fix erroneous non-isolated counter value writes (closes #74)
- Drop useless writer actors (in AWRS)
  - some async database clients will anyway support concurrent writes
  - in all other cases, concurrent writes should be a backend-specific implementation
- extended replay tests
