### PR TITLE
Dynamo Snapshotting

### DIFF
--- a/es-journal/es-journal-dynamodb/build.sbt
+++ b/es-journal/es-journal-dynamodb/build.sbt
@@ -1,4 +1,8 @@
-resolvers ++= Seq("sonatype" at "https://oss.sonatype.org/content/repositories/snapshots/", "spray repo" at "http://repo.spray.io")
+resolvers ++= Seq(
+  "sonatype"             at "https://oss.sonatype.org/content/repositories/snapshots/",
+  "spray releases repo"  at "http://repo.spray.io",
+  "spray nightlies repo" at "http://nightlies.spray.io/"
+)
 
 libraryDependencies ++= Seq(
   "com.sclasen" %%  "spray-dynamodb" % "0.2.0-SNAPSHOT" % "compile",

--- a/es-journal/es-journal-dynamodb/build.sbt
+++ b/es-journal/es-journal-dynamodb/build.sbt
@@ -1,8 +1,8 @@
 resolvers ++= Seq("sonatype" at "https://oss.sonatype.org/content/repositories/snapshots/", "spray repo" at "http://repo.spray.io")
 
 libraryDependencies ++= Seq(
-  "com.sclasen" %%  "spray-dynamodb" % "0.1.2" % "compile",
-  "com.sclasen" %%  "spray-aws" % "0.1.2" % "compile"
+  "com.sclasen" %%  "spray-dynamodb" % "0.2.0-SNAPSHOT" % "compile",
+  "com.sclasen" %%  "spray-aws" % "0.2.0-SNAPSHOT" % "compile"
 )
 
 OsgiKeys.importPackage := Seq(

--- a/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSpec.scala
+++ b/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSpec.scala
@@ -17,7 +17,10 @@ package org.eligosource.eventsourced.journal.dynamodb
 
 import akka.actor.ActorSystem
 
-import org.eligosource.eventsourced.journal.common.{JournalProps, PersistentJournalSpec}
+import org.eligosource.eventsourced.journal.common.{PersistentReplaySpec, JournalProps, PersistentJournalSpec}
 
 class DynamoDBJournalSpec extends PersistentJournalSpec with DynamoDBJournalSupport
+
+class DynamoDBReplaySpec extends PersistentReplaySpec with DynamoDBJournalSupport
+
 

--- a/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
+++ b/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
@@ -10,24 +10,19 @@ trait DynamoDBJournalSupport extends BeforeAndAfterEach with BeforeAndAfterAll {
   this: Suite =>
 
   var _app = System.currentTimeMillis().toString
-  val spraySystem = ActorSystem("spray")
 
   def journalProps: JournalProps = {
     val key = sys.env("AWS_ACCESS_KEY_ID")
     val secret = sys.env("AWS_SECRET_ACCESS_KEY")
     val table = sys.env("TEST_TABLE")
     val app = _app
-    DynamoDBJournalProps(table, app, key, secret, counterShards = 10, system = spraySystem, operationTimeout = Timeout(30 seconds))
+    DynamoDBJournalProps(table, app, key, secret, counterShards = 10, operationTimeout = Timeout(30 seconds))
   }
 
   override protected def afterEach() {
     _app = System.currentTimeMillis().toString
   }
 
-  override protected def afterAll() {
-    spraySystem.shutdown()
-    spraySystem.awaitTermination()
-  }
 }
 
 class Listener extends Actor {

--- a/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
+++ b/es-journal/es-journal-dynamodb/src/it/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalSupport.scala
@@ -1,13 +1,37 @@
 package org.eligosource.eventsourced.journal.dynamodb
 
-import akka.actor.ActorSystem
+import akka.actor.{DeadLetter, Props, Actor, ActorSystem}
+import org.scalatest.{BeforeAndAfterAll, Suite, BeforeAndAfterEach}
+import org.eligosource.eventsourced.journal.common.JournalProps
+import akka.util.Timeout
+import concurrent.duration._
 
-trait DynamoDBJournalSupport {
-  def journalProps = {
+trait DynamoDBJournalSupport extends BeforeAndAfterEach with BeforeAndAfterAll {
+  this: Suite =>
+
+  var _app = System.currentTimeMillis().toString
+  val spraySystem = ActorSystem("spray")
+
+  def journalProps: JournalProps = {
     val key = sys.env("AWS_ACCESS_KEY_ID")
     val secret = sys.env("AWS_SECRET_ACCESS_KEY")
     val table = sys.env("TEST_TABLE")
-    val app = System.currentTimeMillis().toString
-    DynamoDBJournalProps(table, app, key, secret, counterShards = 10, system = ActorSystem("dynamo-test"))
+    val app = _app
+    DynamoDBJournalProps(table, app, key, secret, counterShards = 10, system = spraySystem, operationTimeout = Timeout(30 seconds))
+  }
+
+  override protected def afterEach() {
+    _app = System.currentTimeMillis().toString
+  }
+
+  override protected def afterAll() {
+    spraySystem.shutdown()
+    spraySystem.awaitTermination()
+  }
+}
+
+class Listener extends Actor {
+  def receive = {
+    case a:DeadLetter ⇒ println(a)
   }
 }

--- a/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournal.scala
+++ b/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournal.scala
@@ -30,13 +30,14 @@ import java.nio.ByteBuffer
 import java.util.Collections
 import java.util.{List => JList, Map => JMap, HashMap => JHMap}
 import org.eligosource.eventsourced.core.JournalProtocol._
-import org.eligosource.eventsourced.core.Message
+import org.eligosource.eventsourced.core.{Snapshot, SnapshotMetadata, Message}
 import org.eligosource.eventsourced.journal.common.serialization._
 import org.eligosource.eventsourced.journal.common.snapshot.HadoopFilesystemSnapshotting
 import org.eligosource.eventsourced.journal.common.support.AsynchronousWriteReplaySupport
 import org.eligosource.eventsourced.journal.common.util._
+import scala.util.{Failure, Success}
 
-private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extends AsynchronousWriteReplaySupport with ActorLogging with HadoopFilesystemSnapshotting {
+private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extends AsynchronousWriteReplaySupport with ActorLogging with HadoopFilesystemSnapshotting { outer =>
   val serialization = MessageSerialization(context.system)
 
   implicit def msgToBytes(msg: Message): Array[Byte] = serialization.serializeMessage(msg)
@@ -45,7 +46,7 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
 
   val channelMarker = Array(1.toByte)
 
-  log.debug("new Journal")
+  log.debug(s"new Journal $props")
 
 
   def counterAtt(cntr: Long) = S(props.eventSourcedApp + Counter + (cntr % maxCounterShards))
@@ -62,7 +63,16 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
 
   val dynamo = new DynamoDBClient(props.clientProps)
 
-  def snapshotter = ???
+  def snapshotter = new Snapshotter {
+    def loadSnapshot(processorId: Int, snapshotFilter: (SnapshotMetadata) => Boolean) =
+      outer.loadSnapshot(processorId, snapshotFilter)
+
+    def saveSnapshot(snapshot: Snapshot) =
+      outer.saveSnapshot(snapshot)
+
+    def snapshotSaved(metadata: SnapshotMetadata) =
+      outer.snapshotSaved(metadata)
+  }
 
   def writer = new DynamoWriter
 
@@ -365,7 +375,8 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
           val msgs = (cmd.toSequenceNr - cmd.fromSequenceNr).toInt + 1
           log.debug(s"replayingIn from ${from} for up to ${msgs}")
           val replayer = context.actorOf(Props(new ReplayResequencer(from, msgs, p(_, cmd.target))))
-          Future.sequence(replayer ? ReplayDone :: replayIn(from, msgs, cmd.processorId, replayer).toList)
+          val done = replayer ? ReplayDone
+          Future.sequence(done:: replayIn(from, msgs, cmd.processorId, replayer).toList)
       }
       Future.sequence(replayOps)
     }
@@ -375,7 +386,8 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
       val msgs = (cmd.toSequenceNr - cmd.fromSequenceNr).toInt + 1
       log.debug(s"replayingIn from ${from} for up to ${msgs}")
       val replayer = context.actorOf(Props(new ReplayResequencer(from, msgs, p)))
-      Future.sequence(replayer ? ReplayDone ::replayIn(from, msgs, cmd.processorId, replayer).toList)
+      val done = replayer ? ReplayDone
+      Future.sequence(done ::replayIn(from, msgs, cmd.processorId, replayer).toList)
     }
 
     def executeReplayOutMsgs(cmd: ReplayOutMsgs, p: (Message) => Unit, sender: ActorRef) = {
@@ -383,7 +395,8 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
       val msgs = (cmd.toSequenceNr - cmd.fromSequenceNr).toInt + 1
       log.debug(s"replayingOut from ${from} for up to ${msgs}")
       val replayer = context.actorOf(Props(new ReplayResequencer(from, msgs, p)))
-      Future.sequence(replayer ? ReplayDone ::replayOut(from, msgs, cmd.channelId, replayer).toList)
+      val done = replayer ? ReplayDone
+      Future.sequence(done ::replayOut(from, msgs, cmd.channelId, replayer).toList)
     }
   }
 
@@ -399,7 +412,9 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
     def receive = {
       case (seqnr: Long, Some(message: Message)) => resequence(seqnr, Some(message))
       case (seqnr: Long, None) => resequence(seqnr, None)
-      case ReplayDone => replayDone = Some(sender)
+      case ReplayDone =>
+        replayDone = Some(sender)
+        if(maxMessages == 0L) signalDone()
     }
 
     @scala.annotation.tailrec
@@ -413,10 +428,14 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
       val eo = delayed.remove(delivered + 1)
       if (eo.isDefined) resequence(delivered + 1, eo.get)
       else if (delivered == done) {
-        log.debug("replay resequencer finished, shutting down")
-        replayDone.foreach(_ ! ReplayDone)
-        self ! PoisonPill
+         signalDone()
       }
+    }
+
+    private def signalDone(){
+      log.debug("replay resequencer finished, shutting down")
+      replayDone.foreach(_ ! ReplayDone)
+      self ! PoisonPill
     }
 
   }

--- a/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournal.scala
+++ b/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournal.scala
@@ -61,7 +61,7 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
 
   implicit val ctx = context.system.dispatcher
 
-  val dynamo = new DynamoDBClient(props.clientProps)
+  val dynamo = new DynamoDBClient(props.clientProps(context.system))
 
   def snapshotter = new Snapshotter {
     def loadSnapshot(processorId: Int, snapshotFilter: (SnapshotMetadata) => Boolean) =
@@ -304,7 +304,7 @@ private [dynamodb] class DynamoDBJournal(val props: DynamoDBJournalProps) extend
 
   class DynamoWriter extends Writer {
 
-    val dynamoWriter = new DynamoDBClient(props.clientProps)
+    val dynamoWriter = new DynamoDBClient(props.clientProps(context.system))
 
     def executeDeleteOutMsg(cmd: DeleteOutMsg) = {
       val del: DeleteItemRequest = new DeleteItemRequest().withTableName(props.journalTable).withKey(cmd)

--- a/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalProps.scala
+++ b/es-journal/es-journal-dynamodb/src/main/scala/org/eligosource/eventsourced/journal/dynamodb/DynamoDBJournalProps.scala
@@ -43,7 +43,6 @@ case class DynamoDBJournalProps(
   operationTimeout: Timeout = Timeout(10 seconds),
   replayOperationTimeout: Timeout = Timeout(1 minute),
   counterShards:Int=10000,
-  system: ActorSystem,
   factory: Option[ActorRefFactory] = None,
   dynamoEndpoint:String = "dynamodb.us-east-1.amazonaws.com",
   name: Option[String] = None, dispatcherName: Option[String] = None,
@@ -111,7 +110,7 @@ case class DynamoDBJournalProps(
   def createJournalActor =
     new DynamoDBJournal(this)
 
-  def clientProps =
+  def clientProps(system:ActorSystem) =
     DynamoDBClientProps(key, secret, operationTimeout, system, factory.getOrElse(system), dynamoEndpoint)
 }
 
@@ -119,6 +118,6 @@ object DynamoDBJournalProps {
   /**
    * Java API.
    */
-  def create(journalTable: String, eventSourcedApp: String, key: String, secret: String, system: ActorSystem) =
-    DynamoDBJournalProps(journalTable, eventSourcedApp, key, secret, system = system)
+  def create(journalTable: String, eventSourcedApp: String, key: String, secret: String) =
+    DynamoDBJournalProps(journalTable, eventSourcedApp, key, secret)
 }


### PR DESCRIPTION
Tests passing.  This is now using a SNAPSHOT of spray-aws due to the akka-2.2-RC1 dep.  When 2.2 final happens Ill cut a release of spray-aws.

```

> project eventsourced-journal-dynamodb
[info] Set current project to eventsourced-journal-dynamodb (in build file:/Users/scott/github.com/eligosource/eventsourced/)
> it:test
[warn] Credentials file /Users/scott/.sbt/.credentials does not exist
[warn] Credentials file /Users/scott/.sbt/.credentials does not exist
[warn] Credentials file /Users/scott/.sbt/.credentials does not exist
2013-06-26 21:13:03.539 java[44154:7a03] Unable to load realm info from SCDynamicStore
Jun 26, 2013 9:13:06 PM org.apache.hadoop.util.NativeCodeLoader <clinit>
WARNING: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[info] DynamoDBJournalSpec:
[info] A journal
[info] - must persist and timestamp input messages
[info] - must persist but not timestamp output messages
[info] - must persist messages with client-defined sequence numbers
[info] - must persist input messages and acknowledgements
[info] - must persist input messages and acknowledgements along with output messages
[info] - must replay iput messages for n processors with a single command
[info] - must tolerate phantom acknowledgements
[info] - recover its counter when started
[info] - reset temporary sender paths for previously persisted output messages
[info] DynamoDBReplaySpec:
[info] A journal
[info]   when used for snapshotted replay
[info]   - must replay to current state from latest snapshot
[info]   - must replay to current state from selected snapshot (sequence number criteria include latest snapshot)
[info]   - must replay to current state from selected snapshot (timestamp criteria include latest snapshot)
[info]   - must replay to current state from selected snapshot (sequence number criteria don't include latest snapshot)
[info]   - must replay to current state from selected snapshot (timestamp criteria don't include latest snapshot)
[info]   - must replay to upper limit from selected snapshot (sequence number criteria don't include latest snapshot)
[info]   - must replay to upper limit from selected snapshot (timestamp criteria don't include latest snapshot)
[info]   - must replay to upper limit from selected snapshot (upper limit tightens selction criteria)
[info]   - must only offer snapshot if snapshot represents current state
[info]   - must only offer snapshot if upper limit excludes messages after snapshot
[info]   when used for non-snapshotted replay
[info]   - must replay all messages
[info]   - must replay all messages if no snapshot could be selected
[info]   - must replay to upper limit
[info]   - must replay to upper limit if no snapshot could be selected
[info]   - must replay from lower limit to upper limit
[info]   - must not replay for lower limit > upper limit
[info] - recognize stored snapshots when started
[info] Passed: : Total 26, Failed 0, Errors 0, Passed 26, Skipped 0
[success] Total time: 36 s, completed Jun 26, 2013 9:13:36 PM

```
