### PR TITLE
RectiveMongo dirver's actor system is being shut down with the journal

### DIFF
--- a/es-journal/es-journal-mongodb-reactive/src/main/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournal.scala
+++ b/es-journal/es-journal-mongodb-reactive/src/main/scala/org/eligosource/eventsourced/journal/mongodb/reactive/MongodbReactiveJournal.scala
@@ -211,7 +211,10 @@ private [eventsourced] class MongodbReactiveJournal(props: MongodbReactiveJourna
   override def stop() {
     import scala.concurrent.duration._
     implicit val timeout = 30.seconds
-    connection.askClose()
+    val system = connection.actorSystem
+    connection.askClose() onComplete {
+      case _ => system.shutdown()
+    }
   }
 }
 


### PR DESCRIPTION
If the driver's actor system is not shut down it sometimes prevents
application process from gracefull termination (even when sys.exit(0) is called)
and causes thread leaks
